### PR TITLE
#1 Add battery percentage

### DIFF
--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -103,6 +103,7 @@ func main() {
 		readings := []string{
 			"temperature_indoors",
 			"temperature_outdoors",
+			"battery_percentage",
 		}
 		for {
 			// Get readings from the Prometheus exporter

--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -150,7 +150,7 @@ func main() {
 			indoor.TempSensor.CurrentTemperature.SetValue(indoorReading)
 			outdoor.TempSensor.CurrentTemperature.SetValue(outdoorReading)
 			batteryPercentageRounded := int(math.RoundToEven(float64(batteryPercentage)))
-			batteryLevel.SetValue(batteryPercentageRounded)
+			battery.BatteryLevel.SetValue(batteryPercentageRounded)
 			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%%", indoorReading, outdoorReading, batteryPercentageRounded))
 
 			// Time between readings

--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -46,11 +46,6 @@ func main() {
 		},
 	)
 
-	battery := service.NewBatteryService()
-	batteryLevel := characteristic.NewBatteryLevel()
-	battery.Service.AddCharacteristic(batteryLevel.Characteristic)
-	bridge.AddService(battery.Service)
-
 	indoor := accessory.NewTemperatureSensor(
 		accessory.Info{
 			Name:             "Indoor",
@@ -65,6 +60,11 @@ func main() {
 		50.0, // Max sensor value
 		0.1,  // Step value
 	)
+
+	battery := service.NewBatteryService()
+	batteryLevel := characteristic.NewBatteryLevel()
+	battery.Service.AddCharacteristic(batteryLevel.Characteristic)
+	indoor.AddService(battery.Service)
 
 	outdoor := accessory.NewTemperatureSensor(
 		accessory.Info{

--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -149,8 +149,8 @@ func main() {
 			// Set the temperature reading on the accessory
 			indoor.TempSensor.CurrentTemperature.SetValue(indoorReading)
 			outdoor.TempSensor.CurrentTemperature.SetValue(outdoorReading)
-			batteryPercentageRounded := int(math.RoundToEven(float64(batteryPercentage)))
-			battery.BatteryLevel.SetValue(batteryPercentageRounded)
+			batteryPercentageRounded := math.RoundToEven(float64(batteryPercentage))
+			battery.BatteryLevel.SetValue(int(batteryPercentageRounded))
 			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%%", indoorReading, outdoorReading, batteryPercentageRounded))
 
 			// Time between readings

--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -149,7 +149,7 @@ func main() {
 			indoor.TempSensor.CurrentTemperature.SetValue(indoorReading)
 			outdoor.TempSensor.CurrentTemperature.SetValue(outdoorReading)
 			batteryLevel.SetValue(int(batteryPercentage))
-			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%", indoorReading, outdoorReading, batteryPercentage))
+			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%%", indoorReading, outdoorReading, batteryPercentage))
 
 			// Time between readings
 			time.Sleep(secondsBetweenReadings)

--- a/homekit-oregon-scientific-idtw211r.go
+++ b/homekit-oregon-scientific-idtw211r.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -148,8 +149,9 @@ func main() {
 			// Set the temperature reading on the accessory
 			indoor.TempSensor.CurrentTemperature.SetValue(indoorReading)
 			outdoor.TempSensor.CurrentTemperature.SetValue(outdoorReading)
-			batteryLevel.SetValue(int(batteryPercentage))
-			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%%", indoorReading, outdoorReading, batteryPercentage))
+			batteryPercentageRounded := int(math.RoundToEven(float64(batteryPercentage)))
+			batteryLevel.SetValue(batteryPercentageRounded)
+			log.Println(fmt.Sprintf("Indoors: %f°C, outdoors: %f°C, battery: %f%%", indoorReading, outdoorReading, batteryPercentageRounded))
 
 			// Time between readings
 			time.Sleep(secondsBetweenReadings)


### PR DESCRIPTION
Resolves #1 

- [x] Add battery percentage from sighmon/oregon-temperature-prometheus#3

## Details

1. Re-build: `go build homekit-oregon-scientific-idtw211r.go`
1. Run: `./homekit-oregon-scientific-idtw211r -port=8000`
1. Note the battery level appears on the `indoors` temperature sensor